### PR TITLE
Harden diskcache in the mount command.

### DIFF
--- a/girder_client_mount/girder_client_mount.py
+++ b/girder_client_mount/girder_client_mount.py
@@ -362,6 +362,7 @@ class ClientFuse(fuse.Operations):
                         self.diskcache['cache'][key] = data
                     except Exception:
                         logger.exception('diskcache threw an exception in set')
+                if isinstance(data, bytes):
                     result += data[max(0, offset - idxoffset):
                                    min(len(data), offset + size - idxoffset)]
                 else:


### PR DESCRIPTION
diskcache returns small objects as byte arrays rather than buffered objects.